### PR TITLE
Fix #10 Support different hosts for API and Website

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,19 +4,25 @@ const messageFormatter = require('./lib/messageFormatter');
 const slackUtils = require('./lib/slackUtils');
 
 const configuration = {
-    jiraHost: process.env.JIRA_HOST,
-    projectsKeys: process.env.JIRA_PROJECTS_KEYS.split(','),
-    jiraUser: process.env.JIRA_USER,
-    jiraPwd: process.env.JIRA_PWD,
-  },
+  jiraAPIHost: process.env.JIRA_API_HOST,
+  jiraHost: process.env.JIRA_HOST,
+  projectsKeys: process.env.JIRA_PROJECTS_KEYS.split(','),
+  jiraUser: process.env.JIRA_USER,
+  jiraPwd: process.env.JIRA_PWD,
+},
   jiraApi = jira(configuration),
   parser = messageParser(configuration),
   formatter = messageFormatter(configuration),
   JIRA_KEY_MATCHER = /[A-Z0-9]*-\d+/i;
 let bot;
 
+const DEBUG = (message) => {
+  bot.logger.debug('JIRA-ISSUE-FETCHER: ' + message);
+}
+
 module.exports = (robot) => {
   bot = robot;
+  DEBUG('Started!');
   bot.hear(JIRA_KEY_MATCHER, (res) => {
     if (slackUtils.isBotMessage(res.message)) {
       return;

--- a/lib/jira.js
+++ b/lib/jira.js
@@ -3,7 +3,7 @@ const JiraApi = require('jira-client');
 module.exports = function (config) {
   const jira = new JiraApi({
     protocol: 'https',
-    host: config.jiraHost,
+    host: config.jiraAPIHost,
     username: config.jiraUser,
     password: config.jiraPwd,
     apiVersion: '2',


### PR DESCRIPTION
Thought I would be able to get the correct URL directly from the JSON result of the details but they don't provide it...

```json
{
	  "expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
	  "id": "48539",
	  "self": "https://issues.sierrawireless.com/rest/api/2/issue/48539",
	  "key": "OPE-233",
	  "fields": {
	  "customfield_12010": null,
	  "customfield_11562": null,
	  "customfield_15123": null,
	  "fixVersions": [],
	  "customfield_10110": "9223372036854775807",
	  "customfield_12012": null,
	  "customfield_11321": null,
	  "customfield_12411": null,
	[...]
}
```
And instead of trying to compute it from some URLs we can find in the JSON, I decided to add another config parameter to have both the API host and the Website host.